### PR TITLE
Move glide files to root package

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: b07aa8ec9256d2e42a361ba250140a776992e15d5d29ab0d6000a8424f5f9c64
-updated: 2017-09-28T12:56:36.271614253-07:00
+hash: f4080dd5fcbbe91c903ee349e59b194fe3dc51052e69e5f2fd7d0beaa5586378
+updated: 2017-10-24T14:21:31.313161093-07:00
 imports:
 - name: github.com/coreos/go-systemd
   version: 1f9909e51b2dab2487c26d64c8f2e7e580e4c9f5
   subpackages:
   - journal
 - name: github.com/coreos/pkg
-  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
   - capnslog
 - name: github.com/davecgh/go-spew
@@ -58,8 +58,6 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/rook/operator-kit
-  version: 46d3b4a820e8f44425be3cfd8ff20ea63b058a66
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
@@ -119,8 +117,10 @@ imports:
   - pkg/apis/apiextensions
   - pkg/apis/apiextensions/v1beta1
   - pkg/client/clientset/clientset
+  - pkg/client/clientset/clientset/fake
   - pkg/client/clientset/clientset/scheme
   - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
+  - pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
 - name: k8s.io/apimachinery
   version: 728b986edb9bd4bb8a022a8cc13573a97ecc2239
   subpackages:
@@ -168,32 +168,55 @@ imports:
   version: 42a124578af9e61f5c6902fa7b6b2cb6538f17d2
   subpackages:
   - discovery
+  - discovery/fake
   - kubernetes
+  - kubernetes/fake
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
+  - kubernetes/typed/admissionregistration/v1alpha1/fake
   - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta1/fake
   - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1/fake
   - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authentication/v1beta1/fake
   - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1/fake
   - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/authorization/v1beta1/fake
   - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v1/fake
   - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2alpha1/fake
   - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1/fake
   - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/batch/v2alpha1/fake
   - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/certificates/v1beta1/fake
   - kubernetes/typed/core/v1
+  - kubernetes/typed/core/v1/fake
   - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/extensions/v1beta1/fake
   - kubernetes/typed/networking/v1
+  - kubernetes/typed/networking/v1/fake
   - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/policy/v1beta1/fake
   - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1alpha1/fake
   - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/rbac/v1beta1/fake
   - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/settings/v1alpha1/fake
   - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1/fake
   - kubernetes/typed/storage/v1beta1
+  - kubernetes/typed/storage/v1beta1/fake
   - pkg/api/v1/ref
   - pkg/version
   - rest
   - rest/watch
+  - testing
   - tools/cache
   - tools/clientcmd/api
   - tools/metrics
@@ -203,4 +226,14 @@ imports:
   - util/integer
 - name: k8s.io/kubernetes
   version: df7f4b3526a580ef122aaeef61ab52842a60a88b
-testImports: []
+  subpackages:
+  - pkg/util/version
+testImports:
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,8 @@
-package: github.com/rook/operator-kit/sample-operator
+package: github.com/rook/operator-kit
 import:
 - package: github.com/coreos/pkg
   subpackages:
   - capnslog
-- package: github.com/rook/operator-kit
 - package: k8s.io/client-go
   version: 42a124578af9e61f5c6902fa7b6b2cb6538f17d2
 - package: k8s.io/apimachinery

--- a/sample-operator/README.md
+++ b/sample-operator/README.md
@@ -4,10 +4,13 @@ The sample operator creates a custom resources and watches for changes.
 
 ### Build
 ```bash
-# pull all the libraries needed (this may take a while with all the Kubernetes dependencies)
-glide install
+# pull all the libraries needed for operator-kit (this may take a while with all the Kubernetes dependencies)
+glide install  --strip-vendor
 
-# build the go binary
+# change directory to sample-operator
+cd sample-operator
+
+# build the sample operator binary
 CGO_ENABLED=0 GOOS=linux go build
 
 # build the docker container


### PR DESCRIPTION
The vendor directory generated by glide will be in the same directory as the glide files. 

This should be in the root directory, otherwise go will be unable to find the vendored files when building the root package.