### PR TITLE
Pin kubernetes 1.8.2 in the lock file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,7 +53,7 @@
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "a4fa9574c7aa73b2fc54e251eb9524d0482bb592"
+  revision = "bfb48d37839bcacb52be3f539ffac5abcda7e195"
 
 [[projects]]
   branch = "master"
@@ -101,7 +101,7 @@
   branch = "master"
   name = "github.com/gregjones/httpcache"
   packages = [".","diskcache"]
-  revision = "22a0b1feae53974ed4cfe27bcce70dba061cc5fd"
+  revision = "2bcd89a1743fd4b373f7370ce8ddc14dfbd18229"
 
 [[projects]]
   branch = "master"
@@ -112,8 +112,8 @@
 [[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "6240e1e7983a85228f7fd9c3e1b6932d46ec58e2"
-  version = "1.0.3"
+  revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
+  version = "1.0.4"
 
 [[projects]]
   branch = "master"
@@ -125,7 +125,7 @@
   branch = "master"
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
-  revision = "61a3095943e4e55a9305ac68a71cd0bd191d6096"
+  revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
   branch = "master"
@@ -161,7 +161,7 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","lex/httplex"]
-  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
+  revision = "80e70a3f7765a5661a179fd8399b4db2c72646fb"
 
 [[projects]]
   branch = "master"
@@ -179,7 +179,7 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [[projects]]
   branch = "release-1.8"
@@ -188,10 +188,10 @@
   revision = "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
 
 [[projects]]
-  branch = "release-1.8"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/apis/apiextensions","pkg/apis/apiextensions/v1beta1","pkg/client/clientset/clientset","pkg/client/clientset/clientset/fake","pkg/client/clientset/clientset/scheme","pkg/client/clientset/clientset/typed/apiextensions/v1beta1","pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake"]
-  revision = "5bc0d8f05a92b3a09bcf1a9db442a29c0b7a514d"
+  revision = "e509bb64fe1116e12a32273a2032426aa1a5fd26"
+  version = "kubernetes-1.8.2"
 
 [[projects]]
   branch = "release-1.8"
@@ -200,16 +200,16 @@
   revision = "019ae5ada31de202164b118aee88ee2d14075c31"
 
 [[projects]]
-  branch = "release-5.0"
   name = "k8s.io/client-go"
   packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","rest","rest/watch","testing","tools/cache","tools/clientcmd/api","tools/metrics","tools/pager","tools/reference","transport","util/cert","util/flowcontrol","util/integer"]
-  revision = "3c9596422809744570e7b344a5597b4ad8aaabfb"
+  revision = "2ae454230481a7cb5544325e12ad7658ecccd19b"
+  version = "v5.0.1"
 
 [[projects]]
-  branch = "release-1.8"
   name = "k8s.io/code-generator"
   packages = ["cmd/client-gen","cmd/client-gen/args","cmd/client-gen/generators","cmd/client-gen/generators/fake","cmd/client-gen/generators/scheme","cmd/client-gen/generators/util","cmd/client-gen/path","cmd/client-gen/types"]
-  revision = "6db2ee6aa9ab51230d6e0d970b398274a88e81b0"
+  revision = "1f9d929a2d32f787df8d29f987f31aff1501c0f8"
+  version = "kubernetes-1.8.2"
 
 [[projects]]
   branch = "master"
@@ -224,14 +224,14 @@
   revision = "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 
 [[projects]]
-  branch = "release-1.8"
   name = "k8s.io/kubernetes"
   packages = ["pkg/util/version"]
-  revision = "f068265da462b25127737c991bfc2d9edd8f4e13"
+  revision = "bdaeafa71f6c7c04636251031f93464384d54963"
+  version = "v1.8.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e13a2ac14b2140980a09da21a77265184e34dd741f824bc3447afb3d8239fb15"
+  inputs-digest = "2e686f7b705a83a9e256b2a02b71ec3289f6822ce8a677597862a23cb89c238a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,28 +27,27 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  branch = "release-1.8"
+  version = "=v1.8.2"
 
 [[constraint]]
   name = "k8s.io/api"
-  branch = "release-1.8"
-  
+  version = "kubernetes-1.8.2"
+
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  branch = "release-1.8"
+  version = "kubernetes-1.8.2"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.8"
+  version = "kubernetes-1.8.2"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  branch = "release-1.8"
+  version = "kubernetes-1.8.2"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  branch = "release-5.0"
-
-[[constraint]]
+  version = "v5.0.0"
+  [[constraint]]
   name = "k8s.io/code-generator"
-  branch = "release-1.8"
+  version = "kubernetes-1.8.2"

--- a/resource_test.go
+++ b/resource_test.go
@@ -75,5 +75,5 @@ func TestCreateTPRCustomResource(t *testing.T) {
 
 	assert.Equal(t, tprName, tpr.ObjectMeta.Name)
 	assert.Equal(t, "v1alpha", tpr.Versions[0].Name)
-	assert.Equal(t, "ThirdPartyResource for Rook example", tpr.Description)
+	assert.Equal(t, "ThirdPartyResource for example", tpr.Description)
 }


### PR DESCRIPTION
Need to pin kubernetes/kubernetes to 1.8.2. Otherwise, 1.8.4 will be pulled in from this repo, while other k8s repos will still be at 1.8.2 and can result in build errors