### PR TITLE
Include a tiny nudge to run docker-env in readme

### DIFF
--- a/sample-operator/README.md
+++ b/sample-operator/README.md
@@ -18,6 +18,7 @@ cd sample-operator
 CGO_ENABLED=0 GOOS=linux go build
 
 # build the docker container
+# Note: If you are using minikube, don't forget to run "eval $(minikube docker-env)" first!
 docker build -t sample-operator:0.1 .
 ```
 


### PR DESCRIPTION
I lost some time trying to understand why, unlike what the readme stated, the command `kubectl get pod -l app=sample-operator` showed the error status `ImagePullBackoff`, rather than `Running`. It turns out I'd forgotten to source `minikube docker-env`. I suspect the vast majority of people who run this readme will have better `minikube` bootstrap scripts than I do, but perhaps including this note will help some other traveler in the future and make the onboarding even smoother than it already is.